### PR TITLE
Add Privacy Policy and Terms of Use pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,8 @@ import { Graveyard } from "@/pages/Graveyard";
 import { About } from "@/pages/About";
 import { Blog } from "@/pages/Blog";
 import { BlogPost } from "@/pages/BlogPost";
+import { Privacy } from "@/pages/Privacy";
+import { Terms } from "@/pages/Terms";
 import { NotFound } from "@/pages/NotFound";
 
 function Nav() {
@@ -45,25 +47,35 @@ function Nav() {
 
 function Footer() {
   return (
-    <footer className="border-t border-border mt-12 py-6 text-center text-sm text-muted-foreground">
-      Powered by{" "}
-      <a
-        href="https://getalby.com/alby-hub?ref=lncurl"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-terminal hover:underline"
-      >
-        Alby Hub
-      </a>{" "}
-      +{" "}
-      <a
-        href="https://nwc.dev"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-terminal hover:underline"
-      >
-        Nostr Wallet Connect
-      </a>
+    <footer className="border-t border-border mt-12 py-6 text-center text-sm text-muted-foreground space-y-3">
+      <div>
+        Powered by{" "}
+        <a
+          href="https://getalby.com/alby-hub?ref=lncurl"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-terminal hover:underline"
+        >
+          Alby Hub
+        </a>{" "}
+        +{" "}
+        <a
+          href="https://nwc.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-terminal hover:underline"
+        >
+          Nostr Wallet Connect
+        </a>
+      </div>
+      <div className="flex justify-center gap-4 font-mono text-xs">
+        <Link to="/privacy" className="hover:text-foreground transition-colors">
+          Privacy
+        </Link>
+        <Link to="/terms" className="hover:text-foreground transition-colors">
+          Terms
+        </Link>
+      </div>
     </footer>
   );
 }
@@ -82,6 +94,8 @@ export default function App() {
               <Route path="/about" element={<About />} />
               <Route path="/blog" element={<Blog />} />
               <Route path="/blog/:slug" element={<BlogPost />} />
+              <Route path="/privacy" element={<Privacy />} />
+              <Route path="/terms" element={<Terms />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </main>

--- a/frontend/src/pages/Privacy.tsx
+++ b/frontend/src/pages/Privacy.tsx
@@ -1,0 +1,220 @@
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const LAST_UPDATED = "June 21, 2026";
+
+export function Privacy() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold">Privacy Policy</h1>
+        <p className="text-muted-foreground">
+          What lncurl.lol collects, and what it doesn't.
+        </p>
+        <p className="text-sm mt-1 text-muted-foreground font-mono">
+          Last updated: {LAST_UPDATED}
+        </p>
+      </div>
+
+      {/* TL;DR */}
+      <Card className="border-terminal">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-terminal">
+            TL;DR
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>
+            There are no accounts and no sign-up. We don't ask for your name,
+            email, or any personal information. Wallets are created with a single
+            HTTP call and identified only by their connection secret, which we
+            cannot recover for you.
+          </p>
+          <p>
+            The little data we do touch exists to run the service, stop abuse,
+            and keep the lights on. We don't sell it.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* What we collect */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            WHAT WE COLLECT
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div>
+            <p className="font-bold">IP addresses</p>
+            <p className="text-muted-foreground">
+              When you create a wallet we temporarily process your IP address to
+              enforce rate limits (wallet creation is capped per IP per hour). It
+              is not tied to a profile and is not used to identify you beyond
+              abuse prevention.
+            </p>
+          </div>
+
+          <div>
+            <p className="font-bold">Wallet metadata</p>
+            <p className="text-muted-foreground">
+              We store the operational data needed to run each wallet: its
+              lightning address, creation time, balance, and lifecycle status
+              (alive or dead). Wallets are custodial and live on a single shared{" "}
+              <a
+                href="https://getalby.com/alby-hub?ref=lncurl"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-terminal hover:underline"
+              >
+                Alby Hub
+              </a>{" "}
+              instance.
+            </p>
+          </div>
+
+          <div>
+            <p className="font-bold">Epitaphs and public stats</p>
+            <p className="text-muted-foreground">
+              If you attach an epitaph (a "last words" message) when creating a
+              wallet, that message is{" "}
+              <strong>public</strong>. It is displayed on the{" "}
+              <Link to="/graveyard" className="text-terminal hover:underline">
+                Graveyard
+              </Link>{" "}
+              when the wallet dies, along with the wallet's generated name and
+              how long it survived. Do not put anything sensitive or personal in
+              an epitaph.
+            </p>
+          </div>
+
+          <div>
+            <p className="font-bold">Analytics</p>
+            <p className="text-muted-foreground">
+              We use{" "}
+              <a
+                href="https://umami.is"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-terminal hover:underline"
+              >
+                Umami
+              </a>
+              , a privacy-friendly, cookieless analytics tool, to count page
+              views and understand which pages get traffic. It does not use
+              cookies and does not collect personal information or build a
+              cross-site profile of you.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* What we don't collect */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            WHAT WE DON'T DO
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <ul className="list-disc list-inside space-y-1 text-muted-foreground">
+            <li>No accounts, no passwords, no email collection.</li>
+            <li>No tracking cookies and no advertising networks.</li>
+            <li>No selling or renting of any data to third parties.</li>
+            <li>No KYC and no identity verification.</li>
+          </ul>
+        </CardContent>
+      </Card>
+
+      {/* Third parties */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            THIRD PARTIES
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="text-muted-foreground">
+            Running a custodial lightning wallet means some data necessarily
+            passes through infrastructure we don't control:
+          </p>
+          <ul className="list-disc list-inside space-y-1 text-muted-foreground">
+            <li>
+              <a
+                href="https://getalby.com/alby-hub?ref=lncurl"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-terminal hover:underline"
+              >
+                Alby Hub
+              </a>{" "}
+              and the{" "}
+              <a
+                href="https://nwc.dev"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-terminal hover:underline"
+              >
+                Nostr Wallet Connect
+              </a>{" "}
+              relays handle wallet operations and connection strings.
+            </li>
+            <li>
+              The bitcoin lightning network is a public payment network. Payment
+              routing data is shared with other nodes by design and is outside
+              our control.
+            </li>
+            <li>
+              Our hosting provider processes requests in order to serve the site.
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+
+      {/* Retention */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            DATA RETENTION
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="text-muted-foreground">
+            When a wallet runs out of sats it is destroyed and its connection
+            stops working. A record of the dead wallet — its name, epitaph, and
+            lifespan — is kept on the public Graveyard for posterity. We retain
+            aggregate, non-identifying service statistics indefinitely.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Contact */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            QUESTIONS
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="text-muted-foreground">
+            This is a small, experimental service. If you have a question about
+            privacy, open an issue on{" "}
+            <a
+              href="https://github.com/rolznz/lncurl"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-terminal hover:underline"
+            >
+              GitHub
+            </a>
+            . See also our{" "}
+            <Link to="/terms" className="text-terminal hover:underline">
+              Terms of Use
+            </Link>
+            .
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/Terms.tsx
+++ b/frontend/src/pages/Terms.tsx
@@ -80,9 +80,9 @@ export function Terms() {
               hosting.
             </li>
             <li>
-              <strong className="text-foreground">Death.</strong> When a wallet's
-              balance can no longer cover the fee, the wallet is permanently
-              destroyed and moved to the{" "}
+              <strong className="text-foreground">Death.</strong> When a
+              wallet's balance can no longer cover the fee, the wallet is
+              permanently destroyed and moved to the{" "}
               <Link to="/graveyard" className="text-terminal hover:underline">
                 Graveyard
               </Link>
@@ -149,8 +149,8 @@ export function Terms() {
             <strong>"as available"</strong>, without warranties of any kind,
             express or implied. We do not guarantee uptime, durability of funds,
             or that the service will keep operating. It is experimental software
-            and may change, break, or shut down at any time. We may delete any or
-            all wallets, with or without notice.
+            and may change, break, or shut down at any time. We may delete any
+            or all wallets, with or without notice.
           </p>
         </CardContent>
       </Card>
@@ -167,9 +167,9 @@ export function Terms() {
             To the maximum extent permitted by law, lncurl.lol and its operators
             are not liable for any loss of funds, data, or profits, or for any
             indirect, incidental, or consequential damages arising from your use
-            of the service. Your maximum recoverable amount is limited to the
-            balance held in your wallet at the time of the claim. You use this
-            service entirely at your own risk.
+            of the service. We do not guarantee your funds to be available or
+            recoverable at any time. You use this service entirely at your own
+            risk and consider any funds you deposit to be immediately lost.
           </p>
         </CardContent>
       </Card>
@@ -183,10 +183,10 @@ export function Terms() {
         </CardHeader>
         <CardContent className="space-y-2 text-sm">
           <p className="text-muted-foreground">
-            You must be of legal age to use this service in your jurisdiction and
-            responsible for complying with the laws that apply to you. We may
-            update these terms at any time; continued use after a change means
-            you accept the updated terms. See also our{" "}
+            You must be of legal age to use this service in your jurisdiction
+            and responsible for complying with the laws that apply to you. We
+            may update these terms at any time; continued use after a change
+            means you accept the updated terms. See also our{" "}
             <Link to="/privacy" className="text-terminal hover:underline">
               Privacy Policy
             </Link>

--- a/frontend/src/pages/Terms.tsx
+++ b/frontend/src/pages/Terms.tsx
@@ -1,0 +1,199 @@
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const LAST_UPDATED = "June 21, 2026";
+
+export function Terms() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold">Terms of Use</h1>
+        <p className="text-muted-foreground">
+          The rules for using lncurl.lol. Short version: it's a toy, don't trust
+          it with money you care about.
+        </p>
+        <p className="text-sm mt-1 text-muted-foreground font-mono">
+          Last updated: {LAST_UPDATED}
+        </p>
+      </div>
+
+      {/* Custody warning */}
+      <Card className="border-danger">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-danger">
+            CUSTODY WARNING
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>
+            lncurl.lol is a <strong>custodial service</strong>. All wallets live
+            on a single shared{" "}
+            <a
+              href="https://getalby.com/alby-hub?ref=lncurl"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-terminal hover:underline"
+            >
+              Alby Hub
+            </a>{" "}
+            instance that we control. You are trusting us to hold your sats.
+          </p>
+          <p>
+            <strong>Do not</strong> store meaningful amounts here. This service
+            is designed for agents, quick tests, and small amounts. Wallets are
+            charged hourly and are destroyed when their balance hits zero — and
+            the sats are gone with them.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* The service */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            THE SERVICE
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="text-muted-foreground">
+            lncurl.lol creates disposable, custodial bitcoin lightning wallets
+            over a single HTTP call. Each wallet returns a Nostr Wallet Connect
+            connection string you can use with any compatible app or agent. By
+            creating or using a wallet, you agree to these terms. If you don't
+            agree, don't use the service.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* How it works / fees */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            FEES &amp; WALLET LIFECYCLE
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <ul className="list-disc list-inside space-y-1 text-muted-foreground">
+            <li>
+              <strong className="text-foreground">Hourly fee.</strong> A small
+              maintenance fee is deducted from each wallet every hour to cover
+              hosting.
+            </li>
+            <li>
+              <strong className="text-foreground">Death.</strong> When a wallet's
+              balance can no longer cover the fee, the wallet is permanently
+              destroyed and moved to the{" "}
+              <Link to="/graveyard" className="text-terminal hover:underline">
+                Graveyard
+              </Link>
+              . Its connection string and lightning address stop working.
+            </li>
+            <li>
+              <strong className="text-foreground">No recovery.</strong> Dead
+              wallets cannot be restored. There is no password reset, no backup,
+              and no support channel to recover funds or access.
+            </li>
+            <li>
+              <strong className="text-foreground">Rate limits.</strong> Wallet
+              creation is rate-limited per IP. We may adjust limits or fees at
+              any time without notice.
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+
+      {/* Acceptable use */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            ACCEPTABLE USE
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="text-muted-foreground">You agree not to:</p>
+          <ul className="list-disc list-inside space-y-1 text-muted-foreground">
+            <li>
+              Use the service for any illegal purpose, including money
+              laundering, fraud, or sanctions evasion.
+            </li>
+            <li>
+              Abuse, overload, or attempt to disrupt the service, its
+              infrastructure, or its rate limits.
+            </li>
+            <li>
+              Attempt to access wallets, data, or systems that are not yours.
+            </li>
+            <li>
+              Put unlawful, abusive, or sensitive content into epitaphs or any
+              other public field. Epitaphs are displayed publicly on the
+              Graveyard.
+            </li>
+          </ul>
+          <p className="text-muted-foreground">
+            We may remove content, destroy wallets, or block access at our sole
+            discretion to keep the service running.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* No warranty */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            NO WARRANTY
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="text-muted-foreground">
+            The service is provided <strong>"as is"</strong> and{" "}
+            <strong>"as available"</strong>, without warranties of any kind,
+            express or implied. We do not guarantee uptime, durability of funds,
+            or that the service will keep operating. It is experimental software
+            and may change, break, or shut down at any time. We may delete any or
+            all wallets, with or without notice.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Liability */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            LIMITATION OF LIABILITY
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="text-muted-foreground">
+            To the maximum extent permitted by law, lncurl.lol and its operators
+            are not liable for any loss of funds, data, or profits, or for any
+            indirect, incidental, or consequential damages arising from your use
+            of the service. Your maximum recoverable amount is limited to the
+            balance held in your wallet at the time of the claim. You use this
+            service entirely at your own risk.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Eligibility & changes */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-mono text-muted-foreground">
+            ELIGIBILITY &amp; CHANGES
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="text-muted-foreground">
+            You must be of legal age to use this service in your jurisdiction and
+            responsible for complying with the laws that apply to you. We may
+            update these terms at any time; continued use after a change means
+            you accept the updated terms. See also our{" "}
+            <Link to="/privacy" className="text-terminal hover:underline">
+              Privacy Policy
+            </Link>
+            .
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds two static legal pages to the landing site:

- **Privacy Policy** — `/privacy`
- **Terms of Use** — `/terms`

Both are wired into the router and linked from the site footer. They follow the existing `About` page conventions (terminal theme, shadcn `Card` layout) and respect the project's lowercase "bitcoin" / "lightning network" and agent-agnostic style rules.

## Why

These pages are **required to use lncurl.lol in third-party integrations**. Several platforms — most notably **WordPress** (and its plugin/app directories), as well as OAuth providers, payment/marketplace listings, and browser extension stores — will not approve or list a service unless it exposes a **publicly accessible Terms of Use and Privacy Policy** at stable URLs. Without these pages the service can't be embedded or distributed through those channels.

## Content

The copy reflects how the service actually behaves, so it's accurate rather than boilerplate:

- Custodial model on a single shared Alby Hub instance
- 1 sat/hour maintenance fee, charged hourly; wallets are destroyed when they can't pay
- Dead wallets are unrecoverable and move to the public Graveyard with their epitaph
- Epitaphs are explicitly flagged as **public** (don't put anything sensitive in them)
- Per-IP rate limiting on wallet creation
- Cookieless [Umami](https://umami.is) analytics; no accounts, no KYC, no cookies, no data sales
- Standard "as is" / no-warranty and limitation-of-liability language for the custody risk

## Changes

- `frontend/src/pages/Privacy.tsx` (new)
- `frontend/src/pages/Terms.tsx` (new)
- `frontend/src/App.tsx` — register `/privacy` and `/terms` routes; add footer links

## Testing

- `yarn typecheck` passes
- Verified `/`, `/privacy`, and `/terms` all render in the Vite dev server

> [!NOTE]
> The wording is a reasonable, accurate starting point but is **not legal advice**. Worth a review against the operator's jurisdiction before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)